### PR TITLE
Function  collect stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Customs
 *.service
 *.timer
+settings.py
 
 # User-specific files
 *.rsuser

--- a/energy.py
+++ b/energy.py
@@ -34,11 +34,13 @@ def fix_data_keys():
 # Write the partition name for partition_table.py
 def partition_name():
     partition_name = 'energydb_' + datetime.now().strftime('%Y%m%d')
-    # Write partition name to file for use in drop_table()
-    with open(f'{settings.workdir}/partition_name','w+',encoding='utf-8') as f:
-        f.write(partition_name)
     return partition_name
-    
+
+def post(webhook, json):
+    # Default header
+    header = {"Content-Type": "application/json"}
+    requests.post(webhook, json, header)
+
 # Set up database connection
 def db_conn():
     try:

--- a/partition_table.py
+++ b/partition_table.py
@@ -29,6 +29,7 @@ def write_partition_name():
         f.write(energy.partition_name())
 
 # Drop the partitioned table with value partition_name from the Previous Day. Retrying mechanism implemented because this tends to fail every few days.
+# Bug for which retrying is implemented has been fixed, but retrying will still be kept around for now.
 @retry(wait_random_min=1000, wait_random_max=2000,stop_max_attempt_number=5)
 def drop_table():
     with open(f'{settings.workdir}/partition_name','r',encoding='utf-8') as f:

--- a/partition_table.py
+++ b/partition_table.py
@@ -1,0 +1,56 @@
+import energy
+from datetime import datetime
+import settings
+import psycopg2
+
+# Execute partition_table daily at 00:00:01 to ensure a new table is created immediately at the start of the day.
+
+# First collect the day's stats and post them.
+def collect_stats():
+    energy.db_conn()
+    try:
+        statsq = "SELECT MAX(VALUE)-MIN(VALUE) FROM energydb GROUP BY sensor;"
+        energy.cursor.execute(statsq)
+        energy.conn.commit()
+        daily_stats = energy.cursor.fetchall()
+        energy.cursor.close()
+    except (Exception, energy.psycopg2.Error) as error:
+        energy.logger().error(f"Something went wrong: {error}")
+
+# Create a database partition. Should execute at midnight every day.
+def partition_table():
+    energy.db_conn()
+    start = datetime.now().replace(hour=0,minute=0,second=0).strftime('%Y-%m-%d %H:%M:%S')
+    end = datetime.now().replace(hour=23,minute=59,second=59).strftime('%Y-%m-%d %H:%M:%S')
+    try:
+        tableq = f"CREATE TABLE {energy.partition_name()} PARTITION OF energydb FOR VALUES FROM ('{start}') TO ('{end}');"
+        energy.cursor.execute(tableq)
+        energy.conn.commit()
+        energy.cursor.close()
+    except:
+        energy.logger().error(f"Something went wrong while creating a new table, best check partition_name in {settings.workdir}")
+    else:
+        energy.logger().info(f"New table created with name: {energy.partition_name()}")
+
+# Drop the partitioned table with value partition_name from the Previous Day.
+def drop_table():
+    with open(f'{settings.workdir}/partition_name','r',encoding='utf-8') as f:
+        pd_partition_name = f.read()
+    # Do not execute drop_table() if partition_name is empty, this means the database is just being initialized.
+    if pd_partition_name != "":
+        energy.db_conn()
+        try:
+            dropq = f"DROP TABLE {pd_partition_name};"
+            energy.cursor.execute(dropq)
+            energy.conn.commit()
+            energy.cursor.close()
+        except:
+            energy.logger().error("Drop table failed")
+        else:
+            energy.logger().info(f"Table dropped: {pd_partition_name}")
+    else:
+        energy.logger().error("Partition_name not set. This must be the first time you're running this script against the initialized postgres instance and something went wrong in partition_table.py.")
+
+if __name__ == "__main__":
+    drop_table()
+    partition_table()

--- a/partition_table.py
+++ b/partition_table.py
@@ -1,7 +1,7 @@
 import energy
 from datetime import datetime
 import settings
-import psycopg2
+from retrying import retry
 
 # Execute partition_table daily at 00:00:01 to ensure a new table is created immediately at the start of the day.
 
@@ -9,13 +9,44 @@ import psycopg2
 def collect_stats():
     energy.db_conn()
     try:
-        statsq = "SELECT MAX(VALUE)-MIN(VALUE) FROM energydb GROUP BY sensor;"
+        statsq = "SELECT MAX(VALUE)-MIN(VALUE),SENSOR FROM energydb GROUP BY sensor;"
         energy.cursor.execute(statsq)
         energy.conn.commit()
         daily_stats = energy.cursor.fetchall()
         energy.cursor.close()
     except (Exception, energy.psycopg2.Error) as error:
         energy.logger().error(f"Something went wrong: {error}")
+    return dict([tuple(reversed(x)) for x in daily_stats])
+
+# Process those stats and send them away
+def process_daily_stats():
+    http_data = {"content": f"{collect_stats()}"}
+    energy.post(settings.daily_stats, http_data)
+
+def write_partition_name():
+    # Write partition name to file for use in drop_table()
+    with open(f'{settings.workdir}/partition_name','w+',encoding='utf-8') as f:
+        f.write(energy.partition_name())
+
+# Drop the partitioned table with value partition_name from the Previous Day. Retrying mechanism implemented because this tends to fail every few days.
+@retry(wait_random_min=1000, wait_random_max=2000,stop_max_attempt_number=5)
+def drop_table():
+    with open(f'{settings.workdir}/partition_name','r',encoding='utf-8') as f:
+        pd_partition_name = f.read()
+    # Do not execute drop_table() if partition_name is empty, this means the database is just being initialized.
+    if pd_partition_name != "":
+        energy.db_conn()
+        try:
+            dropq = f"DROP TABLE {pd_partition_name};"
+            energy.cursor.execute(dropq)
+            energy.conn.commit()
+            energy.cursor.close()
+        except:
+            energy.logger().error(f"Drop table failed! >:(")
+        else:
+            energy.logger().info(f"Table dropped: {pd_partition_name}")
+    else:
+        energy.logger().error("Partition_name not set. This must be the first time you're running this script against the initialized postgres instance and something went wrong in partition_table.py.")
 
 # Create a database partition. Should execute at midnight every day.
 def partition_table():
@@ -31,26 +62,9 @@ def partition_table():
         energy.logger().error(f"Something went wrong while creating a new table, best check partition_name in {settings.workdir}")
     else:
         energy.logger().info(f"New table created with name: {energy.partition_name()}")
-
-# Drop the partitioned table with value partition_name from the Previous Day.
-def drop_table():
-    with open(f'{settings.workdir}/partition_name','r',encoding='utf-8') as f:
-        pd_partition_name = f.read()
-    # Do not execute drop_table() if partition_name is empty, this means the database is just being initialized.
-    if pd_partition_name != "":
-        energy.db_conn()
-        try:
-            dropq = f"DROP TABLE {pd_partition_name};"
-            energy.cursor.execute(dropq)
-            energy.conn.commit()
-            energy.cursor.close()
-        except:
-            energy.logger().error("Drop table failed")
-        else:
-            energy.logger().info(f"Table dropped: {pd_partition_name}")
-    else:
-        energy.logger().error("Partition_name not set. This must be the first time you're running this script against the initialized postgres instance and something went wrong in partition_table.py.")
+        write_partition_name()
 
 if __name__ == "__main__":
+    process_daily_stats()
     drop_table()
     partition_table()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.20.0
+psycopg2==2.7.5
+retrying==1.3.3

--- a/warn_gas_power.py
+++ b/warn_gas_power.py
@@ -48,16 +48,14 @@ def process_power():
     return energy_consumed
 
 def publish():
-    header = {"Content-Type": "application/json"}
-    http_data = {"content": f"{process_power()} KWh verbruikt in 15 minuten :peeposad:"}
-    requests.post(settings.warn_power, json=http_data, headers=header)
-    os.chdir(settings.workdir)
-    with open('gas_consumed','r',encoding='utf-8') as f:
+    http_data = {"content": f"{process_power()} KWh verbruikt in 15 minuten"}
+    energy.post(settings.warn_power, json=http_data)
+    with open(f'{settings.workdir}/gas_consumed','r',encoding='utf-8') as f:
         gc = f.read()
     # Convert process_gas() value to string, because gc is also of class string
     if gc != str(process_gas()):
         http_data = {"content": f"{process_gas()} m3 verbruikt in 15 minuten"}
-        requests.post(settings.warn_gas, json=http_data, headers=header)
+        energy.post(settings.warn_gas, json=http_data)
 
 if __name__ == "__main__":
     publish()


### PR DESCRIPTION
Added:

Partition_table
Drop_table
Process_daily_stats
Requirements

Moved:

Partition name writing (was done every 30 seconds by energy.py, giving bugs in partition_table.py)
Requests.post repetitions into a function energy.post() with the header already set. Only needs data to be sent now.

Scrapped:

All secrets, moved to settings.py.